### PR TITLE
[ROS] add necessary files to the ROS package and lanchers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(kresling)
+
+find_package(catkin REQUIRED COMPONENTS
+  )
+
+
+catkin_package(
+  CATKIN_DEPENDS
+  )
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+  )

--- a/launch/joy_stick.launch
+++ b/launch/joy_stick.launch
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<launch>
+
+  <node pkg="joy" type="joy_node" name="joy_node" output="screen" >
+    <param name="dev" value="/dev/input/js0"/>
+    <param name="coalesce_interval" value="0.05"/>
+  </node>
+
+</launch>

--- a/launch/mocap.launch
+++ b/launch/mocap.launch
@@ -1,0 +1,26 @@
+<launch>
+
+  <arg name="robot_id" default="1"/>
+
+  <node pkg="mocap_optitrack"
+    type="mocap_node"
+    name="mocap_node"
+    respawn="false"
+    launch-prefix=""
+    required="true">
+    <rosparam subst_value="true">
+      rigid_bodies:
+         '$(arg robot_id)':
+               pose: mocap/pose
+               pose2d: mocap/ground_pose
+               child_frame_id: baselink
+               parent_frame_id: world
+      optitrack_config:
+         multicast_address: 239.255.42.99
+         command_port: 1510
+         data_port: 1511
+    </rosparam>
+    <remap from="~mocap/pose" to="mocap/pose" />
+  </node>
+
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>kresling</name>
+  <version>0.0.0</version>
+  <description>The kresling package</description>
+
+  <maintainer email="miyamichi@jsk.imi.i.u-tokyo.ac.jp">Ayano Miyamichi</maintainer>
+  <license>TODO</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>joy</exec_depend>
+  <exec_depend>mocap_optitrack</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosserial</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <export>
+  </export>
+
+</package>


### PR DESCRIPTION
ROSのパッケージ化するために必要なCMakeLists.txtとpackage.xml及びPS4のコントローラとモーキャプを使うためのlaunchファイルを追加しました.
~/xx_ws/src 以下にkreslingのディレクトリを置いて, (xx_wsは何でもいい)
```bash
cd ~/xx_ws
rosdep install -y -r --from-paths src --ignore-src --rosdistro $ROS_DISTRO
catkin build
```
をした後, 
```bash
source ~/xx_ws/devel/setup.bash
```
をしたターミナルでは`roscd kresling`や`roslaunch kresling mocap.launch`などができるようになります. 
ps4のコントローラを使うためのドライバはpipで別途入れる必要があって, 入れ方は https://github.com/jsk-ros-pkg/jsk_aerial_robot/wiki/PlayStation-DualShock4 を参考にできるのですが, 自動で入るパッケージのバージョンが悪いとかで多分バグるので後でいいです.